### PR TITLE
[bugfix]  무중단배포 오류 수정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -51,7 +51,7 @@ jasypt:
 
 server:
   state: blue
-  port: ENC(jBBqJC00hA3ZZmVnfugq+FucDrJ0AZBrC2darLq5gOlFimO+h2zTgeUT3zBxTlgN)
+  port: 8880
 
 management:
   endpoints:


### PR DESCRIPTION
## 관련 이슈
close: #30 

## 작업 내용
- jasypt에서 server-port 가 정상적으로 복호화되지 않는 문제점 때문에  임시적으로 포트 번호를 그대로 적어놓음