### PR TITLE
[bugfix] 입력받는 userId에 숫자도 포함할 수 있게 검증 로직 수정

### DIFF
--- a/src/main/java/com/fastcampus/befinal/presentation/dto/AuthDto.java
+++ b/src/main/java/com/fastcampus/befinal/presentation/dto/AuthDto.java
@@ -30,7 +30,7 @@ public class AuthDto {
         @Schema(example = SWAGGER_USER_ID)
         @NotBlank(message = NOT_BLANK_USER_ID, groups = RequestValidationGroups.NotBlankGroup.class)
         @Size(min = 4, max = 12, message = SIZE_MISMATCH_USER_ID, groups = RequestValidationGroups.SizeGroup.class)
-        @Pattern(regexp = "^[a-zA-Z]+$", message = PATTERN_MISMATCH_USER_ID, groups = RequestValidationGroups.PatternGroup.class)
+        @Pattern(regexp = "^[a-zA-Z0-9]+$", message = PATTERN_MISMATCH_USER_ID, groups = RequestValidationGroups.PatternGroup.class)
         String id,
 
         @Schema(example = SWAGGER_USER_PASSWORD)
@@ -66,7 +66,7 @@ public class AuthDto {
         @Schema(example = SWAGGER_USER_ID)
         @NotBlank(message = NOT_BLANK_USER_ID, groups = RequestValidationGroups.NotBlankGroup.class)
         @Size(min = 4, max = 12, message = SIZE_MISMATCH_USER_ID, groups = RequestValidationGroups.SizeGroup.class)
-        @Pattern(regexp = "^[a-zA-Z]+$", message = PATTERN_MISMATCH_USER_ID, groups = RequestValidationGroups.PatternGroup.class)
+        @Pattern(regexp = "^[a-zA-Z0-9]+$", message = PATTERN_MISMATCH_USER_ID, groups = RequestValidationGroups.PatternGroup.class)
         String id
     ) {}
 
@@ -112,7 +112,7 @@ public class AuthDto {
         @Schema(example = SWAGGER_USER_ID)
         @NotBlank(message = NOT_BLANK_USER_ID, groups = RequestValidationGroups.NotBlankGroup.class)
         @Size(min = 4, max = 12, message = SIZE_MISMATCH_USER_ID, groups = RequestValidationGroups.SizeGroup.class)
-        @Pattern(regexp = "^[a-zA-Z]+$", message = PATTERN_MISMATCH_USER_ID, groups = RequestValidationGroups.PatternGroup.class)
+        @Pattern(regexp = "^[a-zA-Z0-9]+$", message = PATTERN_MISMATCH_USER_ID, groups = RequestValidationGroups.PatternGroup.class)
         String id,
 
         @Schema(example = SWAGGER_USER_PASSWORD)


### PR DESCRIPTION
## 관련 이슈
close: #105 

## 작업 내용
- 숫자로만도 입력이 가능하기 때문에 기존 검증 "^[a-zA-Z]+$"에서 "^[a-zA-Z0-9]+$"로 변경
