### PR TITLE
[bugfix] 지적광고 상세보기 수정

### DIFF
--- a/src/main/java/com/fastcampus/befinal/domain/repository/AdvertisementRepositoryCustom.java
+++ b/src/main/java/com/fastcampus/befinal/domain/repository/AdvertisementRepositoryCustom.java
@@ -100,8 +100,14 @@ public class AdvertisementRepositoryCustom {
                 ad.advertiser,
                 ad.adCategory.category,
                 ad.postDateTime,
-                ad.assignee.name,
-                ad.modifier.name,
+                new CaseBuilder()
+                    .when(ad.assignee.isNotNull())
+                    .then(ad.assignee.name)
+                    .otherwise(""),
+                new CaseBuilder()
+                    .when(ad.modifier.isNotNull())
+                    .then(ad.modifier.name)
+                    .otherwise(""),
                 ad.adContent.content
                 ))
             .from(ad)


### PR DESCRIPTION
## 관련 이슈
close: #99 

## 작업 내용
- 지적광고 상세보기에서 담당자와 수정자가 null값일때 나던 오류를 수정
- queryDsl에서 left조인을 해서 해당 id값이 null값일때에도 정상적으로 query 결과가 나오도록 수정