### PR TITLE
[bugfix] 관리자 대시보드 잔여배분량이 정상적으로 표시되도록 수정

### DIFF
--- a/src/main/java/com/fastcampus/befinal/domain/repository/AdvertisementRepositoryCustom.java
+++ b/src/main/java/com/fastcampus/befinal/domain/repository/AdvertisementRepositoryCustom.java
@@ -120,8 +120,21 @@ public class AdvertisementRepositoryCustom {
                     .otherwise(0).sum()
                 ))
             .from(ad)
-            .where(isInCurrentPeriod())
+            .where(isCurrentAdvertisementIdWithinPeriod())
             .fetchOne();
+    }
+
+    private BooleanExpression isCurrentAdvertisementIdWithinPeriod() {
+        LocalDate now = LocalDate.now();
+
+        String year = String.valueOf(now.getYear());
+        String month = String.format("%02d", now.getMonthValue());
+        String baseTerm = now.getDayOfMonth() > 15 ? "2" : "1";
+
+        String startAdvertisementId = baseTerm.equals("1") ? year + month + "A00001" : year + month + "N00001";
+        String endAdvertisementId = baseTerm.equals("1") ? year + month + "M99999" : year + month + "Z99999";
+
+        return ad.id.goe(startAdvertisementId).and(ad.id.loe(endAdvertisementId));
     }
 
     public List<DashboardInfo.TodayWork> getTodayWorkList() {


### PR DESCRIPTION
## 관련 이슈
close: #160 

## 작업 내용
- 기존 where 문에 isInCurrentPeriod() 를 사용하고 있는데 해당 메서드는 assignDateTime을 기준으로 잡기 때문에 assignDateTime가 null인 미배분 광고를 찾는 조건으로 적합하지 않음
- isCurrentAdvertisementIdWithinPeriod() 메서드를 생성하여 수정
- isCurrentAdvertisementIdWithinPeriod() 메서드는 현재 period의 시작 광고 id와 마지막 광고 id 범위를 기준으로 조건 생성