### PR TITLE
[bugfix] 관리자 대시보드 작업자별 진행률에 정상적인 값을 주도록 수정

### DIFF
--- a/src/main/java/com/fastcampus/befinal/domain/repository/AdvertisementRepositoryCustom.java
+++ b/src/main/java/com/fastcampus/befinal/domain/repository/AdvertisementRepositoryCustom.java
@@ -225,6 +225,7 @@ public class AdvertisementRepositoryCustom {
             .join(userSummary)
             .on(ad.assignee.id.eq(userSummary.id)
                 .or(ad.modifier.id.eq(userSummary.id)))
+            .where(userSummary.name.ne("-"))
             .groupBy(userSummary.id)
             .fetch();
     }


### PR DESCRIPTION
## 관련 이슈
close: #163 

## 작업 내용
- 쿼리 select 하는 순서가 거꾸로 되어있어 순서 변경
- 삭제된 유저는 보내지 않도록 하여 name이 "-" 아닌 조건으로 where 문 추가
